### PR TITLE
Improve interactive shell status with prompt_toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "rich>=13.7.1",
     "structlog>=25.4.0",
     "pyfiglet>=1.0.3",
+    "prompt_toolkit>=3.0.51",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- add `prompt_toolkit` dependency
- enhance interactive shell with a powerline-style status bar
- show PocketBase status and watcher info
- fix arrow key behaviour with `PromptSession`

## Testing
- `ruff check src/blendman/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pocketbase')*

------
https://chatgpt.com/codex/tasks/task_e_686e5416bcd08322ba5ea9cf0fdc53ae